### PR TITLE
Feature | ECS-11 Centralize JWT Token Generation Helper

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "WillLuke.nextjs.hasPrompted": true
+}

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,3 +1,4 @@
+import { OrganizationMember } from './../../../../generated/prisma/index.d';
 import prisma from "@/lib/prisma"; 
 import { RegisterUserSchema } from "@/schemas/user.schema";
 import argon2 from "argon2";
@@ -5,6 +6,7 @@ import { NextRequest, NextResponse } from "next/server";
 import handleError from "../../helpers/handleError";
 import { OWNER_PERMISSIONS } from "../permission";
 import { UserRole } from "@/generated/prisma/client";
+import generateToken, { JWTPayload } from "../../helpers/generateToken";
 
 export async function POST(request: NextRequest) {
   try {
@@ -81,6 +83,11 @@ export async function POST(request: NextRequest) {
       });
 
       return { user, organization, organizationMember };
+    });
+
+    const token = generateToken<JWTPayload>({
+      id: result.user.id,
+      organizations: [result.organizationMember ]
     });
 
     const { password: _, ...userResponse } = result.user;

--- a/src/app/api/helpers/generateToken.ts
+++ b/src/app/api/helpers/generateToken.ts
@@ -1,0 +1,30 @@
+import { UserRole } from "@/generated/prisma"
+import jwt from "jsonwebtoken";
+
+export interface JWTPayload extends Record<string, any>{
+    id: string;
+    organizations: {
+        organizationId: string;
+        role: UserRole;
+        permissions: string[];
+    }[];
+}
+
+export default function generateToken<T extends Record<string, string>>(
+    payload: T,
+    options: jwt.SignOptions = {
+        expiresIn: "1w",
+    },
+) {
+    try {
+        const token = jwt.sign(payload, process?.env?.JWT_SECRET || "", options);
+        return token;
+    } catch (error) {
+        {
+            throw {
+                code: "error-generating-jwt",
+                error: "failed to generate jwt token",
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Centralize JWT Token Generation Helper

https://dhushanals.atlassian.net/browse/ECS-11

## Type of Change

- [ ] New feature  
- [ ] Bug fix  
- [X] Refactoring  
- [ ] Security patch  
- [ ] UI/UX improvement  

## Description

Moved JWT token generation logic into a dedicated helper function `generateToken` to improve modularity and reuse. Added support for a typed payload structure, including user ID, organization roles, and permissions.

## What is fixed / implemented?

- Created `generateToken.ts` in `api/helpers/` for centralized token creation.
- Defined a typed `JWTPayload` interface to ensure payload consistency.
- Applied default expiration and secret from environment variables.
- Implemented error handling for JWT generation failure.

## Additional Information

_N/A_

## Screenshots (if applicable)

_N/A_

## Checklist

- [ ] I have added or updated relevant tests to cover the changes.  
- [X] I have performed a self-review of my code.  
- [X] My changes generate no new warnings or errors in development and production builds.  
- [ ] I have verified the changes on multiple devices and browsers (if applicable).  
- [X] Environment variables have been updated (if applicable).  
- [ ] New packages have been installed and documented (if applicable).
